### PR TITLE
Add nameIdentifier to name dependencies

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_name.txt
+++ b/mods_cocina_mappings/mods_to_cocina_name.txt
@@ -677,3 +677,53 @@ Names
     }
   ]
 }
+
+15. Name with valueURI only (authority URI)
+<name valueURI="https://id.loc.gov/authorities/names/123">
+  <affiliation>Stanford</affiliation>
+</name>
+{
+  "contributor": [
+    "name": [
+      {
+        "uri": "https://id.loc.gov/authorities/names/123"
+      },
+      "note": [
+        {
+          "value": "Stanford",
+          "type": "affiliation"
+        }
+      ]
+    ]
+  ]
+}
+
+16. Name with nameIdentifier only (RWO URI)
+<name>
+  <nameIdentifier type="orcid">0000-0000-0000</nameIdentifier>
+  <role>
+    <roleTerm type="code" authority="marcrelator">aut</roleTerm>
+  </role>
+</name>
+{
+  "contributor": [
+    {
+      "identifier": [
+        {
+          "value": "0000-0000-0000",
+          "source": {
+            "code": "orcid"
+          }
+        }
+      ],
+      "role": [
+        {
+          "code": "aut",
+          "source": {
+            "code": "marcrelator"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mods_cocina_mappings/mods_to_cocina_value_dependencies.txt
+++ b/mods_cocina_mappings/mods_to_cocina_value_dependencies.txt
@@ -4,6 +4,6 @@
   c. The attribute 'xlink:href' applied to any element.
 
 2. In some cases the lack of a subelement value means that the entire element should be ignored, even if other subelements have value. These dependencies are:
-  a. If no //name/namePart, //name/etal, name valueURI attribute, or name xlink:href attribute, ignore role and affiliation.
+  a. If no //name/namePart, //name/nameIdentifier, //name/etal, name valueURI attribute, or name xlink:href attribute, ignore role and affiliation.
 
 3. The name subelement etal is used without a value (<etal/>). It should be retained in mappings.


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
<name> with only subelement <nameIdentifier> is valid.