### PR TITLE
Restore missing status to uniform title mapping

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
@@ -279,7 +279,8 @@ How to ID: titleInfo type="uniform"
           "type": "title"
         }
       ],
-      "type": "uniform"
+      "type": "uniform",
+      "status": "primary"
     }
   ]
 }


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Data in MODS missing from COCINA mapping