### PR TITLE
Remove type from standard in geo_extension mappings

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_geo_extension.txt
+++ b/mods_cocina_mappings/mods_to_cocina_geo_extension.txt
@@ -172,8 +172,7 @@
         "value": "decimal"
       },
       "standard": {
-        "code": "EPSG:4326",
-        "type": "coordinate reference system"
+        "code": "EPSG:4326"
       }
     },
     {
@@ -246,8 +245,7 @@
         "value": "decimal"
       },
       "standard": {
-        "code": "EPSG:4326",
-        "type": "coordinate reference system"
+        "code": "EPSG:4326"
       }
     }
   ]
@@ -312,8 +310,7 @@
         "value": "decimal"
       },
       "standard": {
-        "code": "EPSG:4326",
-        "type": "coordinate reference system"
+        "code": "EPSG:4326"
       }
     }
   ]
@@ -378,8 +375,7 @@
         "value": "decimal"
       },
       "standard": {
-        "code": "EPSG:4326",
-        "type": "coordinate reference system"
+        "code": "EPSG:4326"
       }
     }
   ]
@@ -447,8 +443,7 @@
         "value": "decimal"
       },
       "standard": {
-        "code": "EPSG:4326",
-        "type": "coordinate reference system"
+        "code": "EPSG:4326"
       }
     },
     {


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
type not allowed for standard in data model