### PR TITLE
Move "primary" in language mapping example #4

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_language.txt
+++ b/mods_cocina_mappings/mods_to_cocina_language.txt
@@ -45,8 +45,8 @@
 }
 
 4. Multiple languages
-<language>
-  <languageTerm type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng" status="primary">English</languageTerm>
+<language usage="primary">
+  <languageTerm type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng">English</languageTerm>
   <languageTerm type="code" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng">eng</languageTerm>
 </language>
 <language>


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Put usage attribute in correct place.