### PR TITLE
Add mappings for name with life dates

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_name.txt
+++ b/mods_cocina_mappings/mods_to_cocina_name.txt
@@ -727,3 +727,57 @@ Names
     }
   ]
 }
+
+
+17. Name with life dates and type
+<name type="personal">
+  <namePart>Sayers, Dorothy L. (Dorothy Leigh)</namePart>
+  <namePart type="date">1893-1957</namePart>
+<name>
+{
+  "contributor": [
+    {
+      "name": [
+        {
+          "structuredValue": [
+            {
+              "value": "Sayers, Dorothy L. (Dorothy Leigh)",
+              "type": "name"
+            },
+            {
+              "value": "1893-1957",
+              "type": "life dates"
+            }
+          ]
+        }
+      ],
+      "type": "person"
+    }
+  ]
+}
+
+18. Name with life dates and type
+<name>
+  <namePart>Sayers, Dorothy L. (Dorothy Leigh)</namePart>
+  <namePart type="date">1893-1957</namePart>
+<name>
+{
+  "contributor": [
+    {
+      "name": [
+        {
+          "structuredValue": [
+            {
+              "value": "Sayers, Dorothy L. (Dorothy Leigh)",
+              "type": "name"
+            },
+            {
+              "value": "1893-1957",
+              "type": "life dates"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Add mappings with life dates.