### PR TITLE
Add H2 to COCINA RelatedResource mapping

### DIFF
--- a/h2_cocina_mappings/h2_to_cocina_related_resource.txt
+++ b/h2_cocina_mappings/h2_to_cocina_related_resource.txt
@@ -13,6 +13,9 @@ Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Press
     }
   ]
 }
+<relatedItem>
+  <note type="preferred citation">Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Pressure. Professor Maya Aguirre. Department of Earth Sciences, Stanford University.</note>
+</relatedItem>
 
 2. Related link
 "A paper"
@@ -36,3 +39,11 @@ https://www.example.com/paper.html
     }
   ]
 }
+<relatedItem>
+  <titleInfo>
+    <title>A paper</title>
+  </titleInfo>
+  <location>
+    <url>https://www.example.com/paper.html</url>
+  </location>
+</relatedItem>

--- a/h2_cocina_mappings/h2_to_cocina_related_resource.txt
+++ b/h2_cocina_mappings/h2_to_cocina_related_resource.txt
@@ -1,0 +1,32 @@
+1. Related citation
+Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Pressure. Professor Maya Aguirre. Department of Earth Sciences, Stanford University.
+{
+  "relatedResource": [
+    {
+      "type": "related to",
+      "note": [
+        {
+          "value": "Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Pressure. Professor Maya Aguirre. Department of Earth Sciences, Stanford University.",
+          "type": "preferred citation"
+        }
+      ]
+    }
+  ]
+}
+
+2. Related link
+https://www.example.com/paper.html
+{
+  "relatedResource": [
+    {
+      "type": "related to",
+      "access": {
+        "url": [
+          {
+            "value": "https://www.example.com/paper.html"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/h2_cocina_mappings/h2_to_cocina_related_resource.txt
+++ b/h2_cocina_mappings/h2_to_cocina_related_resource.txt
@@ -15,11 +15,17 @@ Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Press
 }
 
 2. Related link
+"A paper"
 https://www.example.com/paper.html
 {
   "relatedResource": [
     {
       "type": "related to",
+      "title": [
+        {
+          "value": "A paper"
+        }
+      ],
       "access": {
         "url": [
           {


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Add H2 mapping for related citation and link