### PR TITLE
Update MODS mapping examples for dateOther

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -76,12 +76,13 @@ Dates
 }
 
 5. Single dateOther
-<originInfo>
+<originInfo eventType="publication">
   <dateOther type="Islamic">1441 AH</dateOther>
 </originInfo>
 {
   "event": [
     {
+      "type": "publication",
       "date": [
         {
           "value": "1441 AH",
@@ -97,24 +98,18 @@ Dates
   ]
 }
 
-5b. dateOther without type
-<originInfo displayLabel="Acquisition date">
-  <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
-</originInfo>
-Should throw a fatal error if dateOther is only date element within originInfo and originInfo does not have an eventType attribute.
-
-5c. dateOther with eventType
-<originInfo eventType="acquisition">
-  <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
+5b. dateOther in Gregorian calendar
+<originInfo eventType="acquisition" displayLabel="Acquisition date">
+  <dateOther encoding="w3cdtf">1992</dateOther>
 </originInfo>
 {
   "event": [
     {
       "type": "acquisition",
+      "displayLabel": "Acquisition date",
       "date": [
         {
-          "value": "1970-11-23",
-          "status": "primary",
+          "value": "1992",
           "encoding": {
             "code": "w3cdtf"
           }
@@ -483,12 +478,13 @@ Should throw a fatal error if dateOther is only date element within originInfo a
 
 20. Julian calendar
 MODS 3.6 and before:
-<originInfo>
+<originInfo eventType="production">
   <dateOther type="Julian">1544-02-02</dateOther>
 </originInfo>
 {
   "event": [
     {
+      "type": "creation",
       "date": [
         {
           "value": "1544-02-02",
@@ -504,7 +500,7 @@ MODS 3.6 and before:
   ]
 }
 MODS 3.7:
-<originInfo>
+<originInfo eventType="production">
   <dateCreated calendar="Julian">1544-02-02</dateCreated>
 </originInfo>
 {


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Prior dateOther mappings lacked data to determine event type and did not account for dateOther used in other than to indicate an alternative calendar