### PR TITLE
Add MODS mapping for multilingual uniform title

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
@@ -429,3 +429,82 @@ How to ID: edge case requiring manual review of records with multiple titleInfo 
     }
   ]
 }
+
+18. Multilingual uniform title
+<titleInfo>
+  <title>Mishnah berurah</title>
+  <subTitle>the classic commentary to Shulchan aruch Orach chayim, comprising the laws of daily Jewish conduct</subTitle>
+</titleInfo>
+<titleInfo type="uniform" nameTitleGroup="1" altRepGroup="02">
+  <title>Mishnah berurah. English & Hebrew</title>
+</titleInfo>
+<name type="personal" usage="primary" altRepGroup="01" nameTitleGroup="1">
+  <namePart>Israel Meir</namePart>
+  <namePart type="termsOfAddress">ha-Kohen</namePart>
+  <namePart type="date">1838-1933</namePart>
+</name>
+<name type="personal" usage="primary" altRepGroup="01" script="" nameTitleGroup="1">
+  <namePart>Israel Meir in Hebrew characters</namePart>
+  <namePart type="date">1838-1933</namePart>
+</name>
+<titleInfo type="uniform" nameTitleGroup="1" altRepGroup="02" script="">
+  <title>Mishnah berurah in Hebrew characters</title>
+</titleInfo>
+{
+  "title": [
+    {
+      "structuredValue": [
+        {
+          "value": "Mishnah berurah",
+          "type": "main title"
+        },
+        {
+          "value": "the classic commentary to Shulchan aruch Orach chayim, comprising the laws of daily Jewish conduct",
+          "type": "subtitle"
+        }
+      ],
+      "status": "primary"
+    },
+    {
+      "parallelValue": [
+        {
+          "structuredValue": [
+            {
+              "value": "Israel Meir",
+              "type": "name"
+            },
+            {
+              "value": "ha-Kohen",
+              "type": "term of address"
+            },
+            {
+              "value": "1838-1933",
+              "type": "life dates"
+            },
+            {
+              "value": "Mishnah berurah. English & Hebrew",
+              "type": "title"
+            }
+          ]
+        },
+        {
+          "structuredValue": [
+            {
+              "value": "Israel Meir in Hebrew characters",
+              "type": "name"
+            },
+            {
+              "value": "1838-1933",
+              "type": "life dates"
+            },
+            {
+              "value": "Mishnah berurah in Hebrew characters",
+              "type": "title"
+            }
+          ]
+        }
+      ],
+      "type": "uniform"
+    }
+  ]
+}


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Add mapping to account for case when uniform title is recorded in multiple languages using the altRepGroup attribute