### PR TITLE
Move authority attributes to placeTerm in MODS mapping

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -1334,7 +1334,7 @@ The authority value goes with the code term and the authorityURI and valueURI va
 }
 
 40. originInfo with displayLabel
-<originInfo displayLabel="Origin" eventType="creation">
+<originInfo displayLabel="Origin" eventType="production">
   <place>
     <placeTerm type="text">Stanford (Calif.)</placeTerm>
   </place>

--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -726,8 +726,8 @@ Place
 
 27. Place - text (authorized)
 <originInfo>
-  <place authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">
-    <placeTerm type="text">Stanford (Calif.)</placeTerm>
+  <place>
+    <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
   </place>
 </originInfo>
 {


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #121 Closes #176 