### PR TITLE
Add H2 mapping for Other form type

### DIFF
--- a/h2_cocina_mappings/h2_to_cocina_form.txt
+++ b/h2_cocina_mappings/h2_to_cocina_form.txt
@@ -236,3 +236,25 @@ https://docs.google.com/spreadsheets/d/1EiGgVqtb6PUJE2cI_jhqnAoiQkiwZtar4tF7NHwS
 <genre authority="aat" valueURI="http://vocab.getty.edu/aat/300026413">technical manuals</genre>
 <typeOfResource>software, multimedia</typeOfResource>
 <typeOfResource>text</typeOfResource>
+
+6. Other - Dance notation (Other type with user-entered subtype)
+{
+  "form": [
+    {
+      "structuredValue": [
+        {
+          "value": "Other",
+          "type": "type"
+        },
+        {
+          "value": "Dance notation",
+          "type": "subtype"
+        }
+      ],
+      "type": "resource type",
+      "source": {
+        "value": "Stanford self-deposit user-supplied terms"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
To provide a H2 mapping for when a user chooses the resource type "Other" and enters a free-text subtype