### PR TITLE
Remove "primary" status when not in source and use type "name" for name part of uniform titles

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
@@ -462,8 +462,7 @@ How to ID: edge case requiring manual review of records with multiple titleInfo 
           "value": "the classic commentary to Shulchan aruch Orach chayim, comprising the laws of daily Jewish conduct",
           "type": "subtitle"
         }
-      ],
-      "status": "primary"
+      ]
     },
     {
       "parallelValue": [

--- a/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
@@ -227,7 +227,7 @@ How to ID: titleInfo type="uniform"
       "structuredValue": [
         {
           "value": "Shakespeare, William, 1564-1616",
-          "type": "person"
+          "type": "name"
           "uri": "http://id.loc.gov/authorities/names/n78095332",
           "source": {
             "uri": "http://id.loc.gov/authorities/names/",

--- a/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
@@ -279,8 +279,7 @@ How to ID: titleInfo type="uniform"
           "type": "title"
         }
       ],
-      "type": "uniform",
-      "status": "primary"
+      "type": "uniform"
     }
   ]
 }
@@ -366,8 +365,7 @@ How to ID: edge case requiring manual review of records with multiple titleInfo 
           }
         }
       ],
-      "type": "parallel",
-      "status": "primary"
+      "type": "parallel"
     }
   ]
 }


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
To make title mappings consistent