### PR TITLE
Add mapping to recordInfo for recordChangeDate

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_recordInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_recordInfo.txt
@@ -148,7 +148,7 @@ NB: Standard may need to be applied on a value by value basis rather than to the
   <descriptionStandard>aacr</descriptionStandard>
   <recordContentSource authority="marcorg">CSt</recordContentSource>
   <recordCreationDate encoding="marc">180305</recordCreationDate>
-  <recordChangeDate encoding='iso8601'>20200718050001.0</recordChangeDate>
+  <recordChangeDate encoding="iso8601">20200718050001.0</recordChangeDate>
   <recordIdentifier source="SIRSI">a12374669</recordIdentifier>
   <recordOrigin>Converted from MARCXML to MODS version 3.6 using MARC21slim2MODS3-6_SDR.xsl (SUL version 1 2018/06/13; LC Revision 1.118 2018/01/31)</recordOrigin>
   <languageOfCataloging>
@@ -184,6 +184,17 @@ NB: Standard may need to be applied on a value by value basis rather than to the
             "value": "180305",
             "encoding": {
               "code": "marc"
+            }
+          }
+        ]
+      },
+      {
+        "type": "modification",
+        "date": [
+          {
+            "value": "20200718050001.0",
+            "encoding": {
+              "code": "iso8601"
             }
           }
         ]


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
To correct omitted mapping in recordInfo