### PR TITLE
Fix URL in MODS geo extension mapping example

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_geo_extension.txt
+++ b/mods_cocina_mappings/mods_to_cocina_geo_extension.txt
@@ -1,7 +1,7 @@
 1. Point coordinates
 <extension displayLabel="geo">
   <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gmd="http://www.isotc211.org/2005/gmd">
-    <rdf:Description rdf:about="http://www.stanford.edu/kk138ps4721">
+    <rdf:Description rdf:about="http://purl.stanford.edu/kk138ps4721">
       <dc:format>image/jpeg</dc:format>
       <dc:type>Image</dc:type>
       <gmd:centerPoint>


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Mapping example had incorrect URL for resource.