### PR TITLE
Fix altRepGroup and nameTitleGroup numbering for multilingual uniform…

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
@@ -436,16 +436,16 @@ How to ID: edge case requiring manual review of records with multiple titleInfo 
 <titleInfo type="uniform" nameTitleGroup="1" altRepGroup="01>
   <title>Mishnah berurah. English & Hebrew</title>
 </titleInfo>
-<name type="personal" usage="primary" altRepGroup="01" nameTitleGroup="1">
+<name type="personal" usage="primary" altRepGroup="02" nameTitleGroup="1">
   <namePart>Israel Meir</namePart>
   <namePart type="termsOfAddress">ha-Kohen</namePart>
   <namePart type="date">1838-1933</namePart>
 </name>
-<name type="personal" usage="primary" altRepGroup="02" script="" nameTitleGroup="1">
+<name type="personal" usage="primary" altRepGroup="02" script="" nameTitleGroup="2">
   <namePart>Israel Meir in Hebrew characters</namePart>
   <namePart type="date">1838-1933</namePart>
 </name>
-<titleInfo type="uniform" nameTitleGroup="1" altRepGroup="02" script="">
+<titleInfo type="uniform" nameTitleGroup="2" altRepGroup="01" script="">
   <title>Mishnah berurah in Hebrew characters</title>
 </titleInfo>
 {


### PR DESCRIPTION
… title MODS mapping example

**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
To correct errors in altRepGroup/nameTitleGroup numbering in MODS multilingual uniform title mapping examples