### PR TITLE
h2_to_cocina_contributor.txt: fix mods for marcrelator host institution

### DIFF
--- a/h2_cocina_mappings/h2_to_cocina_contributor.txt
+++ b/h2_cocina_mappings/h2_to_cocina_contributor.txt
@@ -172,7 +172,7 @@ Stanford University. Host institution.
   <namePart>Stanford University</namePart>
   <role>
     <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/his">his</roleTerm>
-    <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/his">hosting institution</roleTerm>
+    <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/his">host institution</roleTerm>
   </role>
 </name>
 


### PR DESCRIPTION
This is correcting an error in the mapping document

fix already coded in DSA