### PR TITLE
Add primary to H2 COCINA contributor mapping

### DIFF
--- a/h2_cocina_mappings/h2_to_cocina_contributor.txt
+++ b/h2_cocina_mappings/h2_to_cocina_contributor.txt
@@ -321,9 +321,6 @@ Concert. Event.
 }
 <name type="corporate" usage="primary">
   <namePart>Concert</namePart>
-  <role>
-    <roleTerm type="text">Event</roleTerm>
-  </role>
 </name>
 
 7. Multiple contributors - person
@@ -769,6 +766,7 @@ Stanford University. Funder.
         }
       ],
       "type": "organization",
+      "status": "primary",
       "role": [
         {
           "value": "Funder",


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #146 