### PR TITLE
Add primary to MODS recordInfo mapping #1

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_recordInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_recordInfo.txt
@@ -15,6 +15,7 @@
     "language": [
       {
         "value": "English",
+        "status": "primary",
         "code": "eng",
         "uri": "http://id.loc.gov/vocabulary/iso639-2/eng",
         "source": {


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #145 