### PR TITLE
h2_to_cocina_contributor:  pub date is status primary / keyDate

### DIFF
--- a/h2_cocina_mappings/h2_to_cocina_contributor.txt
+++ b/h2_cocina_mappings/h2_to_cocina_contributor.txt
@@ -837,7 +837,8 @@ Publication date: Aug. 20, 2020
           "value": "2020-08-20",
           "encoding": {
             "code": "w3cdtf"
-          }
+          },
+          "status": "primary"
         }
       ]
     }


### PR DESCRIPTION
per slack conv w Arcadia:
![image](https://user-images.githubusercontent.com/96775/99826679-8cb25a00-2b0d-11eb-9dcf-e557c45e6769.png)
![image](https://user-images.githubusercontent.com/96775/99826703-9471fe80-2b0d-11eb-95aa-6f956ad3c765.png)
