### PR TITLE
Add option C for Single-term topic subject with authority

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_subject.txt
+++ b/mods_cocina_mappings/mods_to_cocina_subject.txt
@@ -46,6 +46,11 @@ Option B
 <subject authority="lcsh">
   <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
 </subject>
+Option C
+<subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">
+  <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
+</subject>
+
 {
   "subject": [
     {
@@ -59,9 +64,6 @@ Option B
     }
   ]
 }
-<subject authority="lcsh">
-  <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
-</subject>
 
 4. Multi-term topic subject with authority for set
 <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021263">


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Actually seen in data.