### PR TITLE
Fix authorityURI for example.

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_subject.txt
+++ b/mods_cocina_mappings/mods_to_cocina_subject.txt
@@ -327,10 +327,10 @@ Example 2:
 
 11. Name subject with additional terms, authority for terms
 <subject authority="lcsh">
-  <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n78095332">
+  <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n78095332">
     <namePart>Shakespeare, William, 1564-1616</namePart>
   </name>
-  <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects" valueURI="http://id.loc.gov/authorities/subjects/sh99005711">Homes and haunts</topic>
+  <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh99005711">Homes and haunts</topic>
 </subject>
 {
   "subject": [


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Fix authorityURI for example (assuming this is an error, rather than needing to normalize trailing slash).