### PR TITLE
Add MODS mapping example for invalid identifier

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_identifier.txt
+++ b/mods_cocina_mappings/mods_to_cocina_identifier.txt
@@ -30,3 +30,17 @@
     }
   ]
 }
+
+4. Invalid identifier
+<identifier type="lccn" invalid="yes">sn 87042262</identifier>
+{
+  "identifier": [
+    {
+      "value": "sn 87042262",
+      "status": "invalid",
+      "source": {
+        "code": "lccn"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #184 