### PR TITLE
Upcase lccn to be consistent with other identifier types.

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_identifier.txt
+++ b/mods_cocina_mappings/mods_to_cocina_identifier.txt
@@ -39,7 +39,7 @@
       "value": "sn 87042262",
       "status": "invalid",
       "source": {
-        "code": "lccn"
+        "code": "LCCN"
       }
     }
   ]


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
To be consistent with mapping of other identifier types.