### PR TITLE
Standardize use of type and source for identifiers

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_identifier.txt
+++ b/mods_cocina_mappings/mods_to_cocina_identifier.txt
@@ -14,8 +14,7 @@
 {
   "identifier": [
     {
-      "type": "URI",
-      "value": "https://www.wikidata.org/wiki/Q146"
+      "uri": "https://www.wikidata.org/wiki/Q146"
     }
   ]
 }
@@ -37,10 +36,8 @@
   "identifier": [
     {
       "value": "sn 87042262",
-      "status": "invalid",
-      "source": {
-        "code": "lccn"
-      }
+      "type": "LCCN",
+      "status": "invalid"
     }
   ]
 }

--- a/mods_cocina_mappings/mods_to_cocina_identifier.txt
+++ b/mods_cocina_mappings/mods_to_cocina_identifier.txt
@@ -1,10 +1,23 @@
+Identifier mapping is at https://docs.google.com/spreadsheets/d/1d5PokzgXqNykvQeckG2ND43B6i9_CsjfIVwS_IsphS8/edit#gid=0&range=A131
+
 1. Identifier with type
 <identifier type="isbn">1234 5678 9203</identifier>
 {
   "identifier": [
     {
       "value": "1234 5678 9203",
-      "type": "ISBN"
+      "type": "ISBN",
+      "note": [
+        {
+          "type": "type",
+          "value": "isbn",
+          "uri": "http://id.loc.gov/vocabulary/identifiers/isbn",
+          "source": {
+            "value": "Standard Identifier Schemes",
+            "uri": "http://id.loc.gov/vocabulary/identifiers/"
+          }
+        }
+      ]
     }
   ]
 }
@@ -14,7 +27,18 @@
 {
   "identifier": [
     {
-      "uri": "https://www.wikidata.org/wiki/Q146"
+      "uri": "https://www.wikidata.org/wiki/Q146",
+      "note": [
+        {
+          "type": "type",
+          "value": "uri",
+          "uri": "http://id.loc.gov/vocabulary/identifiers/uri",
+          "source": {
+            "value": "Standard Identifier Schemes",
+            "uri": "http://id.loc.gov/vocabulary/identifiers/"
+          }
+        }
+      ]
     }
   ]
 }
@@ -37,7 +61,18 @@
     {
       "value": "sn 87042262",
       "type": "LCCN",
-      "status": "invalid"
+      "status": "invalid",
+      "note": [
+        {
+          "type": "type",
+          "value": "lccn",
+          "uri": "http://id.loc.gov/vocabulary/identifiers/lccn",
+          "source": {
+            "value": "Standard Identifier Schemes",
+            "uri": "http://id.loc.gov/vocabulary/identifiers/"
+          }
+        }
+      ]
     }
   ]
 }

--- a/mods_cocina_mappings/mods_to_cocina_name.txt
+++ b/mods_cocina_mappings/mods_to_cocina_name.txt
@@ -116,11 +116,8 @@ Names
       "type": "person",
       "identifier": [
         {
-          "value": "https://www.wikidata.org/wiki/Q7704207",
-          "type": "URI",
-          "source": {
-            "code": "wikidata"
-          }
+          "uri": "https://www.wikidata.org/wiki/Q7704207",
+          "type": "Wikidata"
         }
       ],
       "note": [
@@ -736,9 +733,7 @@ OK to omit type: pseudonym in MODS mapping.
       "identifier": [
         {
           "value": "0000-0000-0000",
-          "source": {
-            "code": "orcid"
-          }
+          "type": "ORCID"
         }
       ],
       "role": [

--- a/mods_cocina_mappings/mods_to_cocina_recordInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_recordInfo.txt
@@ -207,9 +207,7 @@
     "identifier": [
       {
         "value": "a12374669",
-        "source": {
-          "value": "SIRSI"
-        }
+        "type": "SIRSI"
       }
     ],
     "note": [

--- a/mods_cocina_mappings/mods_to_cocina_relatedItem.txt
+++ b/mods_cocina_mappings/mods_to_cocina_relatedItem.txt
@@ -200,15 +200,11 @@
         "identifier": [
           {
             "value": "6766105",
-            "source": {
-              "value": "SUL catalog key"
-            }
+            "type": "SUL catalog key"
           },
           {
             "value": "3888071",
-            "source": {
-              "code": "oclc"
-            }
+            "type": "OCLC"
           }
         ]
       }

--- a/sample_records/mapped_from_datacite/datacite_full.json
+++ b/sample_records/mapped_from_datacite/datacite_full.json
@@ -33,15 +33,11 @@
             "identifier": [
                 {
                     "value": "0000-0001-5000-0007",
-                    "type": "ORCID",
-                    "source": {"uri": "http://orcid.org/"}
-                }
-            ],
-            "note": [
+                    "type": "ORCID"
+                },
                 {
-                    "value": "DataCite",
                     "uri": "https://ror.org/04wxnsj81",
-                    "source": {"value": "ROR"}
+                    "type": "ROR"
                 }
             ],
             "role": [
@@ -123,16 +119,19 @@
             "identifier": [
                 {
                     "value": "0000-0002-7285-027X",
-                    "type": "ORCID",
-                    "source": {"uri": "http://orcid.org/"}
+                    "type": "ORCID"
                 }
             ],
             "note": [
                 {
                     "value": "California Digital Library",
                     "type": "affiliation",
-                    "uri": "https://ror.org/03yrm5c26",
-                    "source": {"value": "ROR"}
+                    "identifier": [
+                        {
+                            "uri": "https://ror.org/03yrm5c26",
+                            "type": "ROR"
+                        }
+                    ]
                 }
             ],
             "role": [
@@ -271,7 +270,7 @@
                     ],
                     "identifier": [
                         {
-                            "value": "https://doi.org/10.13039/100000001",
+                            "uri": "https://doi.org/10.13039/100000001",
                             "type": "Crossref Funder ID"
                         }
                     ]

--- a/sample_records/mapped_from_mods/dc156hp0190.json
+++ b/sample_records/mapped_from_mods/dc156hp0190.json
@@ -20,7 +20,7 @@
             "identifier": [
                 {
                     "uri": "https://orcid.org/0000-0001-5028-5161",
-                    "source": {"code": "orcid"}
+                    "type": "ORCID"
                 }
             ],
             "role": [
@@ -53,7 +53,7 @@
             "identifier": [
                 {
                     "uri": "https://orcid.org/0000-0002-9672-3873",
-                    "source": {"code": "orcid"}
+                    "type": "ORCID"
                 }
             ],
             "role": [
@@ -86,7 +86,7 @@
             "identifier": [
                 {
                     "uri": "https://orcid.org/0000-0003-2110-9753",
-                    "source": {"code": "orcid"}
+                    "type": "ORCID"
                 }
             ],
             "role": [
@@ -115,7 +115,7 @@
             "identifier": [
                 {
                     "uri": "https://orcid.org/0000-0002-4716-0840",
-                    "source": {"code": "orcid"}
+                    "type": "ORCID"
                 }
             ],
             "role": [
@@ -144,7 +144,7 @@
             "identifier": [
                 {
                     "uri": "https://orcid.org/0000-0002-4780-9566",
-                    "source": {"code": "orcid"}
+                    "type": "ORCID"
                 }
             ],
             "role": [
@@ -173,7 +173,7 @@
             "identifier": [
                 {
                     "uri": "https://orcid.org/0000-0002-5362-4816",
-                    "source": {"code": "orcid"}
+                    "type": "ORCID"
                 }
             ],
             "role": [
@@ -202,7 +202,7 @@
             "identifier": [
                 {
                     "uri": "https://orcid.org/0000-0001-9021-611X",
-                    "source": {"code": "orcid"}
+                    "type": "ORCID"
                 }
             ],
             "role": [
@@ -231,7 +231,7 @@
             "identifier": [
                 {
                     "uri": "https://orcid.org/0000-0002-4829-5739",
-                    "source": {"code": "orcid"}
+                    "type": "ORCID"
                 }
             ],
             "role": [
@@ -260,7 +260,7 @@
             "identifier": [
                 {
                     "uri": "https://orcid.org/0000-0002-5662-9604",
-                    "source": {"code": "orcid"}
+                    "type": "ORCID"
                 }
             ],
             "role": [
@@ -289,7 +289,7 @@
             "identifier": [
                 {
                     "uri": "https://orcid.org/0000-0002-0671-689X",
-                    "source": {"code": "orcid"}
+                    "type": "ORCID"
                 }
             ],
             "role": [
@@ -318,7 +318,7 @@
             "identifier": [
                 {
                     "uri": "https://orcid.org/0000-0002-3783-5509",
-                    "source": {"code": "orcid"}
+                    "type": "ORCID"
                 }
             ],
             "role": [
@@ -468,7 +468,7 @@
     "identifier": [
         {
             "uri": "https://doi.org/10.25740/ppax-bf07",
-            "source": {"code": "doi"}
+            "type": "DOI"
         }
     ],
     "purl": "https://purl.stanford.edu/vk217bh4910",
@@ -481,7 +481,7 @@
             "identifier": [
                 {
                     "uri": "https://doi.org/10.25740/ppax-bf07",
-                    "source": {"code": "doi"}
+                    "type": "DOI"
                 }
             ],
             "purl": "https://purl.stanford.edu/vk217bh4910"
@@ -494,7 +494,7 @@
             "identifier": [
                 {
                     "uri": "https://doi.org/10.25740/sb4q-wj06",
-                    "source": {"code": "doi"}
+                    "type": "DOI"
                 }
             ],
             "purl": "https://purl.stanford.edu/jc488jb7715"
@@ -507,7 +507,7 @@
             "identifier": [
                 {
                     "uri": "https://doi.org/10.25740/2zme-3q44",
-                    "source": {"code": "doi"}
+                    "type": "DOI"
                 }
             ],
             "purl": "https://purl.stanford.edu/km388vz4371"
@@ -520,7 +520,7 @@
             "identifier": [
                 {
                     "uri": "https://doi.org/10.25740/3jhw-x180",
-                    "source": {"code": "doi"}
+                    "type": "DOI"
                 }
             ],
             "purl": "https://purl.stanford.edu/sr325xz9271"
@@ -533,7 +533,7 @@
             "identifier": [
                 {
                     "uri": "https://doi.org/10.25740/0fbp-re41",
-                    "source": {"code": "doi"}
+                    "type": "DOI"
                 }
             ],
             "purl": "https://purl.stanford.edu/qw012qy2533"
@@ -545,8 +545,8 @@
             ],
             "identifier": [
                 {
-                    "value": "https://doi.org/10.25740/64cr-bc95",
-                    "source": {"code": "doi"}
+                    "uri": "https://doi.org/10.25740/64cr-bc95",
+                    "type": "DOI"
                 }
             ],
             "purl": "https://purl.stanford.edu/vf806tr8954"
@@ -558,8 +558,8 @@
             ],
             "identifier": [
                 {
-                    "value": "https://doi.org/10.25740/c8bw-ar96",
-                    "source": {"code": "doi"}
+                    "uri": "https://doi.org/10.25740/c8bw-ar96",
+                    "type": "DOI"
                 }
             ],
             "purl": "https://purl.stanford.edu/kp222tm1554"
@@ -571,8 +571,8 @@
             ],
             "identifier": [
                 {
-                    "value": "https://doi.org/10.25740/pknx-5s37",
-                    "source": {"code": "doi"}
+                    "uri": "https://doi.org/10.25740/pknx-5s37",
+                    "type": "DOI"
                 }
             ],
             "purl": "https://purl.stanford.edu/nk828sc2920"

--- a/sample_records/mapped_from_mods/gg244ft6232.json
+++ b/sample_records/mapped_from_mods/gg244ft6232.json
@@ -299,7 +299,7 @@
         "identifier": [
             {
                 "value": "a6914736",
-                "source": {"value": "SIRSI"}
+                "type": "SIRSI"
             }
         ],
         "note": [


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #197 and makes identifier mappings consistent