### PR TITLE
Add MODS mapping for uniform title with corporate author

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_titleInfo.txt
@@ -553,3 +553,29 @@ Only change in round-trip mapping is dropping empty script attributes. In the ro
     }
   ]
 }
+
+20. Uniform title with corporate author
+<titleInfo type="uniform" nameTitleGroup="1">
+  <title>Laws, etc. (United States code service)</title>
+</titleInfo>
+<name type="corporate" nameTitleGroup="1">
+  <namePart>United States</namePart>
+</name>
+Note: <name> is also mapped to "contributor" with type "organization" (see mods_to_cocina_name.txt)
+{
+  "title": [
+    {
+      "structuredValue": [
+        {
+          "value": "United States",
+          "type": "name"
+        },
+        {
+          "value": "Laws, etc. (United States code service)",
+          "type": "title"
+        }
+      ],
+      "type": "uniform"
+    }
+  ]
+}


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #200