### PR TITLE
mods_to_cocina_location.txt example 11 has no authority code to be included

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_location.txt
+++ b/mods_cocina_mappings/mods_to_cocina_location.txt
@@ -281,7 +281,6 @@ Map MODS physicalLocation to COCINA digitalLocation if the value contains / or \
         "type": "repository",
         "displayLabel": "Repository",
         "source": {
-          "code": "naf",
           "uri": "http://id.loc.gov/authorities/names/"
         }
       }


### PR DESCRIPTION
## Why was this change made?

example had an error.