### PR TITLE
mods_to_cocina_location example 11 roundtrip fix??

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_location.txt
+++ b/mods_cocina_mappings/mods_to_cocina_location.txt
@@ -300,8 +300,6 @@ Map MODS physicalLocation to COCINA digitalLocation if the value contains / or \
 }
 <location>
   <physicalLocation type="repository" displayLabel="Repository" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/no2014019980">Stanford University. Libraries. Department of Special Collections and University Archives</physicalLocation>
-</location>
-<location>
   <physicalLocation>Call Number: SC0340, Accession 2005-101, Box: 51, Folder: 3</physicalLocation>
 </location>
 


### PR DESCRIPTION
## Why was this change made?

1.  ~~both physicalLocation elements are under same location element when mapping from cocina to fedora.  Is that ok?~~ nevermind.  I hadn't synced up with latest changes in master.  So please do NOT merge this PR.
2. If we leave source code "naf" in  accessContact, then it will show up in first physicalLocation attributes

**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

@ndushay actively working on mapping example 11.

