### PR TITLE
Adjust MODS originInfo mappings with altRepGroup to support roundtripping

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -1199,6 +1199,7 @@ The authority value goes with the code term and the authorityURI and valueURI va
   <publisher>臨川書店</publisher>
   <dateIssued>平成 8 [1996]</dateIssued>
 </originInfo>
+Round trip maps back to original. Rule: anything in an event that does not have an explicit language/script goes in the eng and/or Latn originInfo.
 {
   "event": [
     {
@@ -1327,27 +1328,6 @@ The authority value goes with the code term and the authorityURI and valueURI va
     }
   ]
 }
-<originInfo script="Latn" altRepGroup="1" eventType="publication">
-  <place>
-    <placeTerm type="text">Kyōto-shi</placeTerm>
-  </place>
-  <publisher>Rinsen Shoten</publisher>
-  <dateIssued>Heisei 8 [1996]</dateIssued>
-</originInfo>
-<originInfo script="Hani" altRepGroup="1" eventType="publication">
-  <place>
-    <placeTerm type="text">京都市</placeTerm>
-  </place>
-  <publisher>臨川書店</publisher>
-  <dateIssued>平成 8 [1996]</dateIssued>
-</originInfo>
-<originInfo eventType="publication">
-  <place>
-    <placeTerm type="code" authority="marccountry">ja</placeTerm>
-  </place>
-  <dateIssued encoding="marc">1996</dateIssued>
-  <issuance>monographic</issuance>
-</originInfo
 
 40. originInfo with displayLabel
 <originInfo displayLabel="Origin" eventType="production">
@@ -1381,6 +1361,7 @@ The authority value goes with the code term and the authorityURI and valueURI va
     <placeTerm>Москва</placeTerm>
   </place>
 </originInfo>
+Round trip maps back to original. Rule: same as #39.
 {
   "event": [
     {
@@ -1437,19 +1418,6 @@ The authority value goes with the code term and the authorityURI and valueURI va
     }
   ]
 }
-<originInfo eventType="production" lang="eng" script="Latn" altRepGroup="1">
-  <place>
-    <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
-  </place>
-</originInfo>
-<originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="1">
-  <place>
-    <placeTerm>Москва</placeTerm>
-  </place>
-</originInfo>
-<originInfo eventType="production">
-  <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
-</originInfo>
 
 42. Multilingual edition
 <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="1">


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Previous originInfo/parallelValue mappings mutated at each MODS<>COCINA transform. New mappings add a rule so that the MODS generated from COCINA is the same as the original MODS. 
