### PR TITLE
Origininfo 2

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -1199,6 +1199,7 @@ The authority value goes with the code term and the authorityURI and valueURI va
   <publisher>臨川書店</publisher>
   <dateIssued>平成 8 [1996]</dateIssued>
 </originInfo>
+Round trip maps back to original. Rule: anything in an event that does not have an explicit language/script goes in the eng and/or Latn originInfo.
 {
   "event": [
     {
@@ -1327,27 +1328,6 @@ The authority value goes with the code term and the authorityURI and valueURI va
     }
   ]
 }
-<originInfo script="Latn" altRepGroup="1" eventType="publication">
-  <place>
-    <placeTerm type="text">Kyōto-shi</placeTerm>
-  </place>
-  <publisher>Rinsen Shoten</publisher>
-  <dateIssued>Heisei 8 [1996]</dateIssued>
-</originInfo>
-<originInfo script="Hani" altRepGroup="1" eventType="publication">
-  <place>
-    <placeTerm type="text">京都市</placeTerm>
-  </place>
-  <publisher>臨川書店</publisher>
-  <dateIssued>平成 8 [1996]</dateIssued>
-</originInfo>
-<originInfo eventType="publication">
-  <place>
-    <placeTerm type="code" authority="marccountry">ja</placeTerm>
-  </place>
-  <dateIssued encoding="marc">1996</dateIssued>
-  <issuance>monographic</issuance>
-</originInfo
 
 40. originInfo with displayLabel
 <originInfo displayLabel="Origin" eventType="production">
@@ -1381,6 +1361,7 @@ The authority value goes with the code term and the authorityURI and valueURI va
     <placeTerm>Москва</placeTerm>
   </place>
 </originInfo>
+Round trip maps back to original. Rule: same as #39.
 {
   "event": [
     {
@@ -1437,19 +1418,6 @@ The authority value goes with the code term and the authorityURI and valueURI va
     }
   ]
 }
-<originInfo eventType="production" lang="eng" script="Latn" altRepGroup="1">
-  <place>
-    <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
-  </place>
-</originInfo>
-<originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="1">
-  <place>
-    <placeTerm>Москва</placeTerm>
-  </place>
-</originInfo>
-<originInfo eventType="production">
-  <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
-</originInfo>
 
 42. Multilingual edition
 <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="1">
@@ -1502,3 +1470,123 @@ The authority value goes with the code term and the authorityURI and valueURI va
     }
   ]
 }
+
+43. Parallel value with no script given in MODS
+Example adapted from hn285fy7937
+<originInfo altRepGroup="0203">
+  <place>
+    <placeTerm type="code" authority="marccountry">cc</placeTerm>
+  </place>
+  <place>
+    <placeTerm type="text">Chengdu</placeTerm>
+  </place>
+  <publisher>Sichuan chu ban ji tuan, Sichuan wen yi chu ban she</publisher>
+  <dateIssued>2005</dateIssued>
+  <edition>Di 1 ban.</edition>
+  <issuance>monographic</issuance>
+</originInfo>
+<originInfo altRepGroup="0203">
+  <place>
+    <placeTerm type="text">[Chengdu in Chinese]</placeTerm>
+  </place>
+  <publisher>[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]</publisher>
+  <dateIssued>2005.</dateIssued>
+  <edition>[Di 1 ban in Chinese]</edition>
+</originInfo>
+{
+  "event": [
+    {
+      "type": "publication",
+      "location": [
+        {
+          "parallelValue": [
+            {
+              "value": "Chengdu"
+            },
+            {
+              "value": "[Chengdu in Chinese]"
+            }
+          ]
+        },
+        # Not included in parallelValue because it's type="code"
+        {
+          "code": "cc",
+          "source": {
+            "code": "marccountry"
+          }
+        }
+      ],
+      "contributor": [
+        {
+          "type": "organization",
+          "name": [
+            {
+              "parallelValue": [
+                {
+                  "value": "Sichuan chu ban ji tuan, Sichuan wen yi chu ban she"
+                },
+                {
+                  "value": "[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]"
+                }
+              ]
+            }
+          ],
+          "role": [
+            {
+              "value": "publisher",
+              "code": "pbl",
+              "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+              "source": {
+                "code": "marcrelator",
+                "uri": "http://id.loc.gov/vocabulary/relators/"
+              }
+            }
+          ]
+        }
+      ],
+      "date": [
+        {
+          "value": "2005"
+        }
+      ],
+      "note": [
+        {
+          "type": "issuance",
+          "value": "monographic"
+        },
+        {
+          "type": "edition",
+          "parallelValue": [
+            {
+              "value": "Di 1 ban."
+            },
+            {
+              "value": "[Di 1 ban in Chinese]"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+<originInfo altRepGroup="1" eventType="publication">
+  <place>
+    <placeTerm type="code" authority="marccountry">cc</placeTerm>
+  </place>
+  <place>
+    <placeTerm type="text">Chengdu</placeTerm>
+  </place>
+  <publisher>Sichuan chu ban ji tuan, Sichuan wen yi chu ban she</publisher>
+  <dateIssued>2005</dateIssued>
+  <edition>Di 1 ban.</edition>
+  <issuance>monographic</issuance>
+</originInfo>
+<originInfo altRepGroup="1" eventType="publication">
+  <place>
+    <placeTerm type="text">[Chengdu in Chinese]</placeTerm>
+  </place>
+  <publisher>[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]</publisher>
+  # The date doesn't have an encoding so it appears in both
+  <dateIssued>2005</dateIssued>
+  <edition>[Di 1 ban in Chinese]</edition>
+</originInfo>

--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -1200,6 +1200,7 @@ The authority value goes with the code term and the authorityURI and valueURI va
   <dateIssued>平成 8 [1996]</dateIssued>
 </originInfo>
 Round trip maps back to original. Rule: anything in an event that does not have an explicit language/script goes in the eng and/or Latn originInfo.
+See #43 for mapping when both attributes are absent.
 {
   "event": [
     {
@@ -1472,9 +1473,9 @@ Round trip maps back to original. Rule: same as #39.
 }
 
 43. Parallel value with no script given in MODS (DRAFT)
-Example adapted from hn285fy7937
+A. Example adapted from hn285fy7937
 <originInfo altRepGroup="0203">
-  <place>
+  <place>        # Not included in parallelValue because it's type="code"
     <placeTerm type="code" authority="marccountry">cc</placeTerm>
   </place>
   <place>
@@ -1508,7 +1509,6 @@ Example adapted from hn285fy7937
             }
           ]
         },
-        # Not included in parallelValue because it's type="code"
         {
           "code": "cc",
           "source": {
@@ -1569,6 +1569,9 @@ Example adapted from hn285fy7937
     }
   ]
 }
+# We don't know which originInfo is eng/Latn, so the rule in #39 cannot apply.
+# Instead, put all values that are not parallel values in both originInfo elements.
+# Parallel values are grouped by index.
 <originInfo altRepGroup="1" eventType="publication">
   <place>
     <placeTerm type="code" authority="marccountry">cc</placeTerm>
@@ -1583,15 +1586,18 @@ Example adapted from hn285fy7937
 </originInfo>
 <originInfo altRepGroup="1" eventType="publication">
   <place>
+    <placeTerm type="code" authority="marccountry">cc</placeTerm>
+  </place>
+  <place>
     <placeTerm type="text">[Chengdu in Chinese]</placeTerm>
   </place>
   <publisher>[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]</publisher>
-  # The date doesn't have an encoding so it appears in both
   <dateIssued>2005</dateIssued>
   <edition>[Di 1 ban in Chinese]</edition>
+  <issuance>monographic</issuance>
 </originInfo>
 
-Example adapted from yc052ns4738
+B. Example adapted from yc052ns4738
 <originInfo altRepGroup="02">
    <place>
       <placeTerm type="code" authority="marccountry">cc</placeTerm>
@@ -1603,15 +1609,6 @@ Example adapted from yc052ns4738
       <placeTerm type="text">[Ruijin]</placeTerm>
    </place>
    <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu</publisher>
-</originInfo>
-<originInfo>
-   <place>
-      <placeTerm type="code" authority="marccountry">cc</placeTerm>
-   </place>
-   <dateIssued encoding="marc" point="start">1933</dateIssued>
-   <dateIssued encoding="marc" point="end">uuuu</dateIssued>
-   <issuance>serial</issuance>
-   <frequency>Irregular</frequency>
 </originInfo>
 <originInfo altRepGroup="02">
    <place>
@@ -1733,4 +1730,140 @@ Example adapted from yc052ns4738
    </place>
    <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese</publisher>
    <frequency>Irregular</frequency>
+</originInfo>
+
+C. Example adapted from bh212vz9239
+<originInfo altRepGroup="02">
+  <place>
+    <placeTerm type="code" authority="marccountry">cc</placeTerm>
+  </place>
+  <place>
+    <placeTerm type="text">Guangdong</placeTerm>
+  </place>
+  <publisher>Guangdong lu jun ce liang ju</publisher>
+  <dateIssued>Minguo 11-18 [1922-1929]</dateIssued>
+  <dateIssued encoding="marc" point="start">1922</dateIssued>
+  <dateIssued encoding="marc" point="end">1929</dateIssued>
+  <issuance>monographic</issuance>
+</originInfo>
+<originInfo altRepGroup="02">
+  <place>
+    <placeTerm type="text">Guangdong in Chinese</placeTerm>
+  </place>
+  <publisher>Guangdong lu jun ce liang ju in Chinese</publisher>
+  <dateIssued>Minguo 11-18 [1922-1929] in Chinese</dateIssued>
+</originInfo>
+{
+  "event": [
+    {
+      "location": [
+        {
+          "code": "cc",
+          "source": {
+            "code": "marccountry"
+          }
+        },
+        {
+          "parallelValue": [
+            {
+              "value": "Guangdong"
+            },
+            {
+              "value": "Guangdong in Chinese"
+            }
+          ]
+        }
+      ],
+      "contributor": [
+        {
+          "type": "organization",
+          "name": [
+            {
+              "parallelValue": [
+                {
+                  "value": "Guangdong lu jun ce liang ju"
+                },
+                {
+                  "value": "Guangdong lu jun ce liang ju in Chinese"
+                }
+              ]
+            }
+          ],
+          "role": [
+            {
+              "value": "publisher",
+              "code": "pbl",
+              "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+              "source": {
+                "code": "marcrelator",
+                "uri": "http://id.loc.gov/vocabulary/relators/"
+              }
+            }
+          ]
+        }
+      ],
+      "date": [
+        {
+          "parallelValue": [
+            {
+              "value": "Minguo 11-18 [1922-1929]"
+            },
+            {
+              "value": "Minguo 11-18 [1922-1929] in Chinese"
+            }
+          ]
+        },
+        {
+          "structuredValue": [
+            {
+              "value": "1922",
+              "type": "start",
+              "encoding": {
+                "code": "marc"
+              }
+            },
+            {
+              "value": "1929",
+              "type": "end",
+              "encoding": {
+                "code": "marc"
+              }
+            }
+          ]
+        }
+      ],
+      "note": [
+        {
+          "type": "issuance",
+          "value": "monographic"
+        }
+      ]
+    }
+  ]
+}
+<originInfo altRepGroup="1">
+  <place>
+    <placeTerm type="code" authority="marccountry">cc</placeTerm>
+  </place>
+  <place>
+    <placeTerm type="text">Guangdong</placeTerm>
+  </place>
+  <publisher>Guangdong lu jun ce liang ju</publisher>
+  <dateIssued>Minguo 11-18 [1922-1929]</dateIssued>
+  <dateIssued encoding="marc" point="start">1922</dateIssued>
+  <dateIssued encoding="marc" point="end">1929</dateIssued>
+  <issuance>monographic</issuance>
+</originInfo>
+<originInfo altRepGroup="1">
+  <place>
+    <placeTerm type="code" authority="marccountry">cc</placeTerm>
+  </place>
+  <place>
+    <placeTerm type="text">Guangdong in Chinese</placeTerm>
+  </place>
+  <publisher>Guangdong lu jun ce liang ju in Chinese</publisher>
+  <dateIssued>Minguo 11-18 [1922-1929] in Chinese</dateIssued>
+  <dateIssued encoding="marc" point="start">1922</dateIssued>
+  <dateIssued encoding="marc" point="end">1929</dateIssued>
+  <issuance>monographic</issuance>
 </originInfo>

--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -1870,3 +1870,128 @@ C. Example adapted from bh212vz9239
   <dateIssued encoding="marc" point="end">1929</dateIssued>
   <issuance>monographic</issuance>
 </originInfo>
+
+44. Multiple originInfo elements with and without eventTypes
+<originInfo>
+  <place>
+    <placeTerm type="code" authority="marccountry">cau</placeTerm>
+  </place>
+  <dateIssued encoding="marc">2020</dateIssued>
+  <copyrightDate encoding="marc">2020</copyrightDate>
+  <issuance>monographic</issuance>
+</originInfo>
+<originInfo eventType="publication">
+  <place>
+    <placeTerm type="text">[Stanford, California]</placeTerm>
+  </place>
+  <publisher>[Stanford University]</publisher>
+  <dateIssued>2020</dateIssued>
+</originInfo>
+<originInfo eventType="copyright notice">
+  <copyrightDate>&#xA9;2020</copyrightDate>
+</originInfo>
+{
+  "event": [
+    {
+      "type": "publication",
+      "location": [
+        {
+          "code": "cau",
+          "source": {
+            "code": "marccountry"
+          }
+        }
+      ],
+      "date": [
+        {
+          "value": "2020",
+          "encoding": {
+            "code": "marc"
+          }
+        }
+      ],
+      "note": [
+        {
+          "type": "issuance",
+          "value": "monographic",
+          "source": {
+            "value": "MODS issuance terms"
+          }
+        }
+      ]
+    },
+    {
+      "type": "publication",
+      "location": [
+        {
+          "value": "[Stanford, Calif.]"
+        }
+      ],
+      "contributor": [
+        {
+          "name": [
+            {
+              "value": "[Stanford University]"
+            }
+          ],
+          "type": "organization",
+          "role": [
+            {
+              "value": "publisher",
+              "code": "pbl",
+              "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+              "source": {
+                "code": "marcrelator",
+                "uri": "http://id.loc.gov/vocabulary/relators/"
+              }
+            }
+          ]
+        }
+      ],
+      "date": [
+        {
+          "value": "2020"
+        }
+      ]
+    },
+    {
+      "type": "copyright notice",
+      "date": [
+        {
+          "value": "2020",
+          "encoding": {
+            "code": "marc"
+          }
+        }
+      ]
+    },
+    {
+      "type": "copyright notice",
+      "date": [
+        {
+          "value": "&#xA9;2020"
+        }
+      ]
+    }
+  ]
+}
+<originInfo eventType="publication">
+  <place>
+    <placeTerm type="code" authority="marccountry">cau</placeTerm>
+  </place>
+  <dateIssued encoding="marc">2020</dateIssued>
+  <issuance>monographic</issuance>
+</originInfo>
+<originInfo eventType="publication">
+  <place>
+    <placeTerm type="text">[Stanford, California]</placeTerm>
+  </place>
+  <publisher>[Stanford University]</publisher>
+  <dateIssued>2020</dateIssued>
+</originInfo>
+<originInfo eventType="copyright notice"
+  <copyrightDate encoding="marc">2020</copyrightDate>
+</originInfo>
+<originInfo eventType="copyright notice">
+  <copyrightDate>&#xA9;2020</copyrightDate>
+</originInfo>

--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -1571,7 +1571,7 @@ A. Example adapted from hn285fy7937
 }
 # We don't know which originInfo is eng/Latn, so the rule in #39 cannot apply.
 # Instead, put all values that are not parallel values in both originInfo elements.
-# Parallel values are grouped by index.
+# Parallel values are grouped by index (i.e. the first of each pair is in the first originInfo, the second in the second one).
 <originInfo altRepGroup="1" eventType="publication">
   <place>
     <placeTerm type="code" authority="marccountry">cc</placeTerm>
@@ -1596,6 +1596,7 @@ A. Example adapted from hn285fy7937
   <edition>[Di 1 ban in Chinese]</edition>
   <issuance>monographic</issuance>
 </originInfo>
+# When converting back to COCINA, duplicate values across the originInfos should be collapsed into one to generate the same record as above.
 
 B. Example adapted from yc052ns4738
 <originInfo altRepGroup="02">
@@ -1605,6 +1606,7 @@ B. Example adapted from yc052ns4738
    <dateIssued encoding="marc" point="start">1933</dateIssued>
    <dateIssued encoding="marc" point="end">uuuu</dateIssued>
    <issuance>serial</issuance>
+   <frequency>Irregular</frequency>
    <place>
       <placeTerm type="text">[Ruijin]</placeTerm>
    </place>
@@ -1617,6 +1619,7 @@ B. Example adapted from yc052ns4738
    <dateIssued encoding="marc" point="start">1933</dateIssued>
    <dateIssued encoding="marc" point="end">uuuu</dateIssued>
    <issuance>serial</issuance>
+   <frequency>Irregular</frequency>
    <place>
       <placeTerm type="text">[Ruijin] in Chinese</placeTerm>
    </place>

--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -1995,3 +1995,59 @@ C. Example adapted from bh212vz9239
 <originInfo eventType="copyright notice">
   <copyrightDate>&#xA9;2020</copyrightDate>
 </originInfo>
+
+45. dateOther with type="developed"
+<originInfo displayLabel="Place of Creation" eventType="production">
+  <place>
+    <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+  </place>
+  <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+  <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+</originInfo>
+{
+  "event": [
+    {
+      "type": "creation",
+      "displayLabel": "Place of Creation",
+      "location": [
+        {
+          "value": "Stanford (Calif.)",
+          "uri": "http://id.loc.gov/authorities/names/n50046557",
+          "source": {
+            "code": "naf",
+            "uri": "http://id.loc.gov/authorities/names"
+          }
+        }
+      ],
+      "date": [
+        {
+          "value": "2003-11-29",
+          "status": "primary",
+          "encoding": {
+            "code": "w3cdtf"
+          }
+        }
+      ]
+    },
+    {
+      "type": "development",
+      "date": [
+        {
+          "value": "2003-12-01",
+          "encoding": {
+            "code": "w3cdtf"
+          }
+        }
+      ]
+    }
+  ]
+}
+<originInfo displayLabel="Place of Creation" eventType="production">
+  <place>
+    <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+  </place>
+  <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+</originInfo>
+<originInfo eventType="development">
+  <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+</originInfo>

--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -1471,7 +1471,7 @@ Round trip maps back to original. Rule: same as #39.
   ]
 }
 
-43. Parallel value with no script given in MODS
+43. Parallel value with no script given in MODS (DRAFT)
 Example adapted from hn285fy7937
 <originInfo altRepGroup="0203">
   <place>
@@ -1589,4 +1589,148 @@ Example adapted from hn285fy7937
   # The date doesn't have an encoding so it appears in both
   <dateIssued>2005</dateIssued>
   <edition>[Di 1 ban in Chinese]</edition>
+</originInfo>
+
+Example adapted from yc052ns4738
+<originInfo altRepGroup="02">
+   <place>
+      <placeTerm type="code" authority="marccountry">cc</placeTerm>
+   </place>
+   <dateIssued encoding="marc" point="start">1933</dateIssued>
+   <dateIssued encoding="marc" point="end">uuuu</dateIssued>
+   <issuance>serial</issuance>
+   <place>
+      <placeTerm type="text">[Ruijin]</placeTerm>
+   </place>
+   <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu</publisher>
+</originInfo>
+<originInfo>
+   <place>
+      <placeTerm type="code" authority="marccountry">cc</placeTerm>
+   </place>
+   <dateIssued encoding="marc" point="start">1933</dateIssued>
+   <dateIssued encoding="marc" point="end">uuuu</dateIssued>
+   <issuance>serial</issuance>
+   <frequency>Irregular</frequency>
+</originInfo>
+<originInfo altRepGroup="02">
+   <place>
+      <placeTerm type="code" authority="marccountry">cc</placeTerm>
+   </place>
+   <dateIssued encoding="marc" point="start">1933</dateIssued>
+   <dateIssued encoding="marc" point="end">uuuu</dateIssued>
+   <issuance>serial</issuance>
+   <place>
+      <placeTerm type="text">[Ruijin] in Chinese</placeTerm>
+   </place>
+   <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese</publisher>
+</originInfo>
+{
+  "event": [
+    {
+      "type": "publication",
+      "location": [
+        {
+          "parallelValue": [
+            {
+              "value": "[Ruijin]"
+            },
+            {
+              "value": "[Ruijin] in Chinese"
+            }
+          ]
+        },
+        {
+          "code": "cc",
+          "source": {
+            "code": "marccountry"
+          }
+        }
+      ],
+      "date": [
+        {
+          "structuredValue": [
+            {
+              "value": "1933",
+              "type": "start",
+              "encoding": {
+                "code": "marc"
+              }
+            },
+            {
+              "value": "uuuu",
+              "type": "end",
+              "encoding": {
+                "code": "marc"
+              }
+            }
+          ]
+        }
+      ],
+      "contributor": [
+        {
+          "type": "organization",
+          "name": [
+            {
+              "parallelValue": [
+                {
+                  "value": "Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu"
+                },
+                {
+                  "value": "Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese"
+                }
+              ]
+            }
+          ],
+          "role": [
+            {
+              "value": "publisher",
+              "code": "pbl",
+              "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+              "source": {
+                "code": "marcrelator",
+                "uri": "http://id.loc.gov/vocabulary/relators/"
+              }
+            }
+          ]
+        }
+      ],
+      "note": [
+        {
+          "type": "issuance",
+          "value": "serial"
+        },
+        {
+          "type": "frequency",
+          "value": "Irregular"
+        }
+      ]
+    }
+  ]
+}
+<originInfo altRepGroup="1" eventType="publication">
+   <place>
+      <placeTerm type="code" authority="marccountry">cc</placeTerm>
+   </place>
+   <dateIssued encoding="marc" point="start">1933</dateIssued>
+   <dateIssued encoding="marc" point="end">uuuu</dateIssued>
+   <issuance>serial</issuance>
+   <place>
+      <placeTerm type="text">[Ruijin]</placeTerm>
+   </place>
+   <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu</publisher>
+   <frequency>Irregular</frequency>
+</originInfo>
+<originInfo altRepGroup="1" eventType="publication">
+   <place>
+      <placeTerm type="code" authority="marccountry">cc</placeTerm>
+   </place>
+   <dateIssued encoding="marc" point="start">1933</dateIssued>
+   <dateIssued encoding="marc" point="end">uuuu</dateIssued>
+   <issuance>serial</issuance>
+   <place>
+      <placeTerm type="text">[Ruijin] in Chinese</placeTerm>
+   </place>
+   <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese</publisher>
+   <frequency>Irregular</frequency>
 </originInfo>


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #223 
To add MODS mappings for the case of multilingual originInfo when script is not indicated