### PR TITLE
Add MODS location mapping for purl with displayLabel and note

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_location.txt
+++ b/mods_cocina_mappings/mods_to_cocina_location.txt
@@ -415,3 +415,22 @@ Map MODS physicalLocation to COCINA digitalLocation if the value contains / or \
 <location>
   <shelfLocator>SC1071</shelfLocator>
 </location>
+
+14. Purl with displayLabel and note
+<location>
+  <url displayLabel="electronic resource" usage="primary display" note="Available to Stanford-affiliated users.">http://purl.stanford.edu/nd782fm8171</url>
+</location>
+{
+  "purl": "http://purl.stanford.edu/nd782fm8171",
+  "access": {
+    "note": [
+      {
+        "value": "Available to Stanford-affiliated users.",
+        "type": "purl access"
+      }
+    ]
+  }
+}
+<location>
+  <url usage="primary display" note="Available to Stanford-affiliated users.">http://purl.stanford.edu/nd782fm8171</url>
+</location>


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #220 

displayLabel may be dropped - it's added to URLs in the MARC2MODS XSLT and will be removed in the next version.