### PR TITLE
Add missing event type to example 43c.

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -1759,6 +1759,7 @@ C. Example adapted from bh212vz9239
 {
   "event": [
     {
+      "type": "publication",
       "location": [
         {
           "code": "cc",


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Add missing event type to example 43c.