### PR TITLE
Add missing displayLabel.

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_subject.txt
+++ b/mods_cocina_mappings/mods_to_cocina_subject.txt
@@ -692,7 +692,8 @@ Based on jw325wd1971
       "source": {
         "value": "EPSG",
         "uri": "http://opengis.net/def/crs/EPSG/0/4326"
-      }
+      },
+      "displayLabel": "WGS84"
     }
   ],
   "subject": [


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Add missing displayLabel to example 19b.