### PR TITLE
Add round trip MODS mapping for publisher with lang attributes

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -962,6 +962,9 @@ The authority value goes with the code term and the authorityURI and valueURI va
     }
   ]
 }
+<originInfo lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables">
+  <publisher>Institut russkoĭ literatury (Pushkinskiĭ Dom)</publisher>
+</originInfo>
 
 33. Publisher - other language
 <originInfo>


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #238 