### PR TITLE
Add MODS originInfo mapping for supplied place

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -2051,3 +2051,39 @@ C. Example adapted from bh212vz9239
 <originInfo eventType="development">
   <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
 </originInfo>
+
+46. Supplied place name
+bv279kp1172
+<originInfo eventType="production" displayLabel="Place of creation">
+  <place supplied="yes">
+    <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n81127564" type="text">Selma (Ala.)</placeTerm>
+  </place>
+  <dateCreated keyDate="yes" encoding="w3cdtf">1965</dateCreated>
+</originInfo>
+{
+  "event": [
+    {
+      "type": "creation",
+      "displayLabel": "Place of creation",
+      "location": [
+        {
+          "type": "supplied",
+          "value": "Selma (Ala.)",
+          "uri": "http://id.loc.gov/authorities/names/n81127564",
+          "source": {
+            "uri": "http://id.loc.gov/authorities/names/"
+          }
+        }
+      ],
+      "date": [
+        {
+          "value": "1965",
+          "encoding": {
+            "code": "w3cdtf"
+          },
+          "status": "primary"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #240 