### PR TITLE
Add MODS mapping example for abstract with type "summary"

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_abstract.txt
+++ b/mods_cocina_mappings/mods_to_cocina_abstract.txt
@@ -63,3 +63,13 @@
     }
   ]
 }
+
+4. Abstract with type "summary"
+<abstract type="summary">This is a summary.</abstract>
+{
+  "note": [
+    "value": "This is a summary.",
+    "type": "summary"
+  ]
+}
+<abstract>This is a summary.</abstract>


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #251 