### PR TITLE
Add mappings for MODS publisher in non-publisher roles

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -2178,6 +2178,42 @@ bv279kp1172
 }
 
 49. Publisher with eventType manufacture
+<originInfo eventType="manufacture">
+  <publisher>Stanford University</publisher>
+  <dateOther type="distribution">2020</dateOther>
+</originInfo>
+{
+  "event": [
+    {
+      "type": "manufacture",
+      "contributor": [
+        {
+          "name": [
+            {
+              "value": "Stanford University"
+            }
+          ],
+          "role": [
+            {
+              "value": "manufacturer",
+              "code": "mfr",
+              "uri": "http://id.loc.gov/vocabulary/relators/mfr"
+              "source": {
+                "code": "marcrelator",
+                "uri": "http://id.loc.gov/vocabulary/relators/"
+              }
+            }
+          ]
+        }
+      ],
+      "date": [
+        {
+          "value": "2020"
+        }
+      ]
+    }
+  ]
+}
 
 50. Publisher with dateOther type
 Adapted from sz423cd8263

--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -2102,8 +2102,46 @@ bv279kp1172
 }
 
 47. Publisher with eventType production
+<originInfo eventType="production">
+  <publisher>Stanford University</publisher>
+  <dateOther type="production">2020</dateOther>
+</originInfo>
+{
+  "event": [
+    {
+      "type": "production",
+      "contributor": [
+        {
+          "name": [
+            {
+              "value": "Stanford University"
+            }
+          ],
+          "role": [
+            {
+              "value": "issuing body",
+              "code": "isb",
+              "uri": "http://id.loc.gov/vocabulary/relators/isb"
+              "source": {
+                "code": "marcrelator",
+                "uri": "http://id.loc.gov/vocabulary/relators/"
+              }
+            }
+          ]
+        }
+      ],
+      "date": [
+        {
+          "value": "2020"
+        }
+      ]
+    }
+  ]
+}
+
 48. Publisher with eventType distribution
 49. Publisher with eventType manufacture
+
 50. Publisher with dateOther type
 Adapted from sz423cd8263
 <originInfo displayLabel="producer">

--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -2140,6 +2140,43 @@ bv279kp1172
 }
 
 48. Publisher with eventType distribution
+<originInfo eventType="distribution">
+  <publisher>Stanford University</publisher>
+  <dateOther type="distribution">2020</dateOther>
+</originInfo>
+{
+  "event": [
+    {
+      "type": "distribution",
+      "contributor": [
+        {
+          "name": [
+            {
+              "value": "Stanford University"
+            }
+          ],
+          "role": [
+            {
+              "value": "distributor",
+              "code": "dst",
+              "uri": "http://id.loc.gov/vocabulary/relators/dst"
+              "source": {
+                "code": "marcrelator",
+                "uri": "http://id.loc.gov/vocabulary/relators/"
+              }
+            }
+          ]
+        }
+      ],
+      "date": [
+        {
+          "value": "2020"
+        }
+      ]
+    }
+  ]
+}
+
 49. Publisher with eventType manufacture
 
 50. Publisher with dateOther type

--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -2100,3 +2100,61 @@ bv279kp1172
     }
   ]
 }
+
+47. Publisher with eventType production
+48. Publisher with eventType distribution
+49. Publisher with eventType manufacture
+50. Publisher with dateOther type
+Adapted from sz423cd8263
+<originInfo displayLabel="producer">
+  <place>
+    <placeTerm>Stanford, Calif.</placeTerm>
+  </place>
+  <publisher>Stanford University, Department of Biostatistics</publisher>
+  <dateOther type="production">2002</dateOther>
+</originInfo>
+{
+  "event": [
+    {
+      "type": "production",
+      "displayLabel": "producer",
+      "location": [
+        {
+          "value": "Stanford, Calif."
+        }
+      ],
+      "contributor": [
+        {
+          "name": [
+            {
+              "value": "Stanford University, Department of Biostatistics"
+            }
+          ],
+          "role": [
+            {
+              "value": "issuing body",
+              "code": "isb",
+              "uri": "http://id.loc.gov/vocabulary/relators/isb"
+              "source": {
+                "code": "marcrelator",
+                "uri": "http://id.loc.gov/vocabulary/relators/"
+              }
+            }
+          ]
+        }
+      ],
+      "date": [
+        {
+          "value": "2002"
+        }
+      ]
+    }
+  ]
+}
+<originInfo displayLabel="producer" eventType="production">
+  <place>
+    <placeTerm>Stanford, Calif.</placeTerm>
+  </place>
+  <publisher>Stanford University, Department of Biostatistics</publisher>
+  <dateOther type="production">2002</dateOther>
+</originInfo>

--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -2121,7 +2121,7 @@ bv279kp1172
             {
               "value": "issuing body",
               "code": "isb",
-              "uri": "http://id.loc.gov/vocabulary/relators/isb"
+              "uri": "http://id.loc.gov/vocabulary/relators/isb",
               "source": {
                 "code": "marcrelator",
                 "uri": "http://id.loc.gov/vocabulary/relators/"
@@ -2159,7 +2159,7 @@ bv279kp1172
             {
               "value": "distributor",
               "code": "dst",
-              "uri": "http://id.loc.gov/vocabulary/relators/dst"
+              "uri": "http://id.loc.gov/vocabulary/relators/dst",
               "source": {
                 "code": "marcrelator",
                 "uri": "http://id.loc.gov/vocabulary/relators/"
@@ -2197,7 +2197,7 @@ bv279kp1172
             {
               "value": "manufacturer",
               "code": "mfr",
-              "uri": "http://id.loc.gov/vocabulary/relators/mfr"
+              "uri": "http://id.loc.gov/vocabulary/relators/mfr",
               "source": {
                 "code": "marcrelator",
                 "uri": "http://id.loc.gov/vocabulary/relators/"
@@ -2245,7 +2245,7 @@ Adapted from sz423cd8263
             {
               "value": "issuing body",
               "code": "isb",
-              "uri": "http://id.loc.gov/vocabulary/relators/isb"
+              "uri": "http://id.loc.gov/vocabulary/relators/isb",
               "source": {
                 "code": "marcrelator",
                 "uri": "http://id.loc.gov/vocabulary/relators/"


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #264 