### PR TITLE
Add explanation to H2 contributor mapping of DataCite role handling

### DIFF
--- a/h2_cocina_mappings/h2_to_cocina_contributor.txt
+++ b/h2_cocina_mappings/h2_to_cocina_contributor.txt
@@ -5,6 +5,10 @@ a) Systems should use this name as sort key when sorting by author
 b) MARC mappings should put this name in the 100 field as main author
 c) Other applications where a single name must be chosen for a purpose (such as constructing a citation using "et al.") should use this name.
 
+DataCite role mappings vary due to its different structure. Most roles map to DataCite contributor types, with the following exceptions:
+1) Creator maps to the Creator property
+2) Conferences, performances, and other events map to the Event resource type
+
 1. Person contributor with single mapped role
 Stanford, Jane. Data collector.
 {


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #126 