### PR TITLE
Change release contributor role to issuing body in H2 sample records

### DIFF
--- a/sample_records/mapped_from_h2/h2_bc275mm5153.json
+++ b/sample_records/mapped_from_h2/h2_bc275mm5153.json
@@ -187,18 +187,12 @@
           "type": "organization",
           "role": [
             {
-              "value": "publisher",
-              "code": "pbl",
-              "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+              "value": "issuing body",
+              "code": "isb",
+              "uri": "http://id.loc.gov/vocabulary/relators/isb",
               "source": {
                 "code": "marcrelator",
                 "uri": "http://id.loc.gov/vocabulary/relators/"
-              }
-            },
-            {
-              "value": "Publisher",
-              "source": {
-                "value": "Stanford self-deposit contributor types"
               }
             }
           ]

--- a/sample_records/mapped_from_h2/h2_bc777tp9978.json
+++ b/sample_records/mapped_from_h2/h2_bc777tp9978.json
@@ -75,18 +75,12 @@
           "type": "organization",
           "role": [
             {
-              "value": "publisher",
-              "code": "pbl",
-              "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+              "value": "issuing body",
+              "code": "isb",
+              "uri": "http://id.loc.gov/vocabulary/relators/isb",
               "source": {
                 "code": "marcrelator",
                 "uri": "http://id.loc.gov/vocabulary/relators/"
-              }
-            },
-            {
-              "value": "Publisher",
-              "source": {
-                "value": "Stanford self-deposit contributor types"
               }
             }
           ]

--- a/sample_records/mapped_from_h2/h2_fq122fg4014.json
+++ b/sample_records/mapped_from_h2/h2_fq122fg4014.json
@@ -86,24 +86,12 @@
           "type": "organization",
           "role": [
             {
-              "value": "Publisher",
-              "source": {
-                "value": "Stanford self-deposit contributor types"
-              }
-            },
-            {
-              "value": "publisher",
-              "code": "pbl",
-              "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+              "value": "issuing body",
+              "code": "isb",
+              "uri": "http://id.loc.gov/vocabulary/relators/isb",
               "source": {
                 "code": "marcrelator",
                 "uri": "http://id.loc.gov/vocabulary/relators/"
-              }
-            },
-            {
-              "value": "Publisher",
-              "source": {
-                "value": "Stanford self-deposit contributor types"
               }
             }
           ]

--- a/sample_records/mapped_from_h2/h2_jv545yc8727.json
+++ b/sample_records/mapped_from_h2/h2_jv545yc8727.json
@@ -77,18 +77,12 @@
           "type": "organization",
           "role": [
             {
-              "value": "publisher",
-              "code": "pbl",
-              "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+              "value": "issuing body",
+              "code": "isb",
+              "uri": "http://id.loc.gov/vocabulary/relators/isb",
               "source": {
                 "code": "marcrelator",
                 "uri": "http://id.loc.gov/vocabulary/relators/"
-              }
-            },
-            {
-              "value": "Publisher",
-              "source": {
-                "value": "Stanford self-deposit contributor types"
               }
             }
           ]

--- a/sample_records/mapped_from_h2/h2_template.json
+++ b/sample_records/mapped_from_h2/h2_template.json
@@ -113,24 +113,12 @@
           "type": "organization",
           "role": [
             {
-              "value": "Publisher",
-              "source": {
-                "value": "Stanford self-deposit contributor types"
-              }
-            },
-            {
-              "value": "publisher",
-              "code": "pbl",
-              "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+              "value": "issuing body",
+              "code": "isb",
+              "uri": "http://id.loc.gov/vocabulary/relators/isb",
               "source": {
                 "code": "marcrelator",
                 "uri": "http://id.loc.gov/vocabulary/relators/"
-              }
-            },
-            {
-              "value": "Publisher",
-              "source": {
-                "value": "Stanford self-deposit contributor types"
               }
             }
           ]


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #276 