### PR TITLE
Add multiple classification example to MODS mappings

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_classification.txt
+++ b/mods_cocina_mappings/mods_to_cocina_classification.txt
@@ -43,3 +43,27 @@
     }
   ]
 }
+
+4. Multiple classifications
+<classification authority="ddc" edition="11">683</classification>
+<classification authority="ddc" edition="12">684</classification>
+{
+  "subject": [
+    {
+      "type": "classification",
+      "value": "683",
+      "source": {
+        "code": "ddc",
+        "version": "11th edition"
+      }
+    },
+    {
+      "type": "classification",
+      "value": "684",
+      "source": {
+        "code": "ddc",
+        "version": "12th edition"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #282 