### PR TITLE
Add H2 mapping for purl property

### DIFF
--- a/h2_cocina_mappings/h2_to_cocina_purl.txt
+++ b/h2_cocina_mappings/h2_to_cocina_purl.txt
@@ -1,0 +1,5 @@
+1. PURL
+PURL: https://purl.stanford.edu/druid
+{
+  "purl": "https://purl.stanford.edu/druid"
+}

--- a/h2_cocina_mappings/h2_to_cocina_purl.txt
+++ b/h2_cocina_mappings/h2_to_cocina_purl.txt
@@ -3,3 +3,16 @@ PURL: https://purl.stanford.edu/druid
 {
   "purl": "https://purl.stanford.edu/druid"
 }
+
+2. PURL in context
+1. PURL
+Title: The brooding sea-star
+PURL: https://purl.stanford.edu/druid
+{
+  "title": [
+    {
+      "value": "The brooding sea-star"
+    }
+  ],
+  "purl": "https://purl.stanford.edu/druid"
+}


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #290 