### PR TITLE
mods_to_cocina_name: fix example numbers

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_name.txt
+++ b/mods_cocina_mappings/mods_to_cocina_name.txt
@@ -489,7 +489,7 @@ Omit "type": "pseudonym" when mapping from MODS.
   ]
 }
 
-11. Multiple names with transliteration (name as value)
+12. Multiple names with transliteration (name as value)
 <name usage="primary" type="personal" script="Cyrl" altRepGroup="0">
   <namePart>Булгаков, Михаил Афанасьевич</namePart>
 </name>
@@ -579,7 +579,7 @@ Omit "type": "pseudonym" when mapping from MODS.
   ]
 }
 
-12. Transliterated name with parts (name as structuredValue)
+13. Transliterated name with parts (name as structuredValue)
 This example is for reference only - doesn't need to be mapped.
 <name usage="primary" type="personal" script="Cyrl" altRepGroup="0">
   <namePart>Булгаков, Михаил Афанасьевич</namePart>
@@ -647,7 +647,7 @@ This example is for reference only - doesn't need to be mapped.
   ]
 }
 
-13. Name with et al.
+14. Name with et al.
 <name type="personal">
   <namePart>Frydman, Judith</namePart>
 </name>
@@ -670,7 +670,7 @@ This example is for reference only - doesn't need to be mapped.
   ]
 }
 
-14. Name with display label
+15. Name with display label
 OK to omit type: pseudonym in MODS mapping.
 <name type="personal" displayLabel="Pseudonym">
   <namePart>Westmacott, Mary</namePart>
@@ -690,7 +690,7 @@ OK to omit type: pseudonym in MODS mapping.
   ]
 }
 
-15. Name with valueURI only (authority URI)
+16. Name with valueURI only (authority URI)
 <name valueURI="https://id.loc.gov/authorities/names/123">
   <affiliation>Stanford</affiliation>
 </name>
@@ -710,7 +710,7 @@ OK to omit type: pseudonym in MODS mapping.
   ]
 }
 
-16. Name with nameIdentifier only (RWO URI)
+17. Name with nameIdentifier only (RWO URI)
 <name>
   <nameIdentifier type="orcid">0000-0000-0000</nameIdentifier>
   <role>
@@ -738,7 +738,7 @@ OK to omit type: pseudonym in MODS mapping.
   ]
 }
 
-17. Full name with additional subelements
+18. Full name with additional subelements
 <name type="personal" usage="primary">
   <namePart>Sarmiento, Domingo Faustino</namePart>
   <namePart type="date">1811-1888</namePart>
@@ -764,7 +764,7 @@ OK to omit type: pseudonym in MODS mapping.
   ]
 }
 
-18. Name with active date - year
+19. Name with active date - year
 If date starts with "active," use type "activity dates" and drop "active" from date value
 <name type="personal">
   <namePart>Yao, Zongyi</namePart>
@@ -791,7 +791,7 @@ If date starts with "active," use type "activity dates" and drop "active" from d
   ]
 }
 
-19. Name with active date - century
+20. Name with active date - century
 <name type="personal">
   <namePart>Inoue, Kaian</namePart>
   <namePart type="date">Active 18th century</namePart>
@@ -817,7 +817,7 @@ If date starts with "active," use type "activity dates" and drop "active" from d
   ]
 }
 
-20. Name with approximate date
+21. Name with approximate date
 <name type="personal">
   <namePart>Lassus, Rudolph de</namePart>
   <namePart type="date">approximately 1563-1625</namePart>
@@ -843,7 +843,7 @@ If date starts with "active," use type "activity dates" and drop "active" from d
   ]
 }
 
-21. Name with language
+22. Name with language
 Example adapted from cp049zn0898
 <name type="corporate" usage="primary" lang="jpn" script="Jpan" altRepGroup="1">
   <namePartRea Metaru Shigen Saisei Gijutsu Kenkyūkai in Japanese characters</namePart>


### PR DESCRIPTION
number 11 now only used once.

**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?

Number 11 was used twice.  I just renumbered from the 2nd one on.  I'm already working on the synching stuff for the dor-services-app, so just nudge me when this gets merged, Arcadia.