### PR TITLE
Add missing eventType to example.

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+++ b/mods_cocina_mappings/mods_to_cocina_originInfo.txt
@@ -963,7 +963,7 @@ The authority value goes with the code term and the authorityURI and valueURI va
     }
   ]
 }
-<originInfo lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables">
+<originInfo eventType="publication" lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables">
   <publisher>Institut russkoĭ literatury (Pushkinskiĭ Dom)</publisher>
 </originInfo>
 


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Add missing eventType to example.