### PR TITLE
Remove extrapolated role info from MODS contributor name mappings

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_name.txt
+++ b/mods_cocina_mappings/mods_to_cocina_name.txt
@@ -267,7 +267,6 @@ Use "term of address" for "ordinal" if type of term cannot be determined from so
 <name type="personal" usage="primary">
   <namePart>Dunnett, Dorothy</namePart>
   <role>
-    <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
     <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
   </role>
 </name>

--- a/mods_cocina_mappings/mods_to_cocina_name.txt
+++ b/mods_cocina_mappings/mods_to_cocina_name.txt
@@ -323,21 +323,13 @@ Use "term of address" for "ordinal" if type of term cannot be determined from so
           "value": "author",
           "code": "aut",
           "source": {
-            "code": "marcrelator",
-            "uri": "http://id.loc.gov/vocabulary/relators/"
+            "code": "marcrelator"
           }
         }
       ]
     }
   ]
 }
-<name type="personal" usage="primary">
-  <namePart>Dunnett, Dorothy</namePart>
-  <role>
-    <roleTerm type="text" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-    <roleTerm type="code" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
-  </role>
-</name>
 
 7f. Role without namePart value
 <name>

--- a/mods_cocina_mappings/mods_to_cocina_name.txt
+++ b/mods_cocina_mappings/mods_to_cocina_name.txt
@@ -230,7 +230,6 @@ Use "term of address" for "ordinal" if type of term cannot be determined from so
   <namePart>Dunnett, Dorothy</namePart>
   <role>
     <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-    <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
   </role>
 </name>
 


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #300  Closes #302 Closes #303 