### PR TITLE
Add example 1b to MODS name mapping for missing name type

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_name.txt
+++ b/mods_cocina_mappings/mods_to_cocina_name.txt
@@ -18,6 +18,24 @@ Names
   ]
 }
 
+1b. Name without type
+<name usage="primary">
+  <namePart>Dunnett, Dorothy</namePart>
+</name>
+# report for remediation
+{
+  "contributor": [
+    {
+      "name": [
+        {
+          "value": "Dunnett, Dorothy"
+        }
+      ],
+      "status": "primary"
+    }
+  ]
+}
+
 2. Corporate name
 <name type="corporate" usage="primary">
   <namePart>Dorothy L. Sayers Society</namePart>


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #307 