### PR TITLE
Add example 5b to MODS name mapping for untyped nameIdentifier

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_name.txt
+++ b/mods_cocina_mappings/mods_to_cocina_name.txt
@@ -152,6 +152,29 @@ Names
   ]
 }
 
+5b. Name with untyped nameIdentifier
+<name type="personal">
+  <namePart>Burnett, Michael W.</namePart>
+  <nameIdentifier>https://orcid.org/0000-0001-5126-5568</nameIdentifier>
+</name>
+{
+  "contributor": [
+    {
+      "name": [
+        {
+          "value": "Burnett, Michael W.",
+        }
+      ],
+      "type": "person",
+      "identifier": [
+        {
+          "uri": "https://orcid.org/0000-0001-5126-5568"
+        }
+      ]
+    }
+  ]
+}
+
 6. Name with ordinal
 <name type="personal" usage="primary">
   <namePart type="given">Elizabeth</namePart>


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #308 