### PR TITLE
Add example 13b for transliterated name with role to MODS name mappings

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_name.txt
+++ b/mods_cocina_mappings/mods_to_cocina_name.txt
@@ -729,6 +729,81 @@ This example is for reference only - doesn't need to be mapped.
   ]
 }
 
+13b. Transliterated name with role
+<name type="corporate" usage="primary" lang="jpn" script="Jpan" altRepGroup="1">
+  <namePart>レアメタル資源再生技術研究会</namePart>
+  <role>
+    <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/cre">cre</roleTerm>
+    <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/cre">creator</roleTerm>
+  </role>
+</name>
+<name type="corporate" lang="jpn" script="Latn" transliteration="ALA-LC Romanization Tables" altRepGroup="1">
+  <namePart>Rea Metaru Shigen Saisei Gijutsu Kenky&#x16B;kai</namePart>
+  <role>
+    <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/cre">cre</roleTerm>
+    <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/cre">creator</roleTerm>
+  </role>
+</name>
+{
+  "contributor": [
+    {
+      name: [
+        {
+          parallelValue: [
+            {
+              "status": 'primary',
+              "valueLanguage": {
+                "code": 'jpn',
+                "source": {
+                  "code": 'iso639-2b'
+                },
+                "valueScript": {
+                  "code": 'Jpan',
+                  "source": {
+                    "code": 'iso15924'
+                  }
+                }
+              },
+              "value": 'レアメタル資源再生技術研究会'
+            },
+            {
+              "valueLanguage": {
+                "code": 'jpn',
+                "source": {
+                  "code": 'iso639-2b'
+                },
+                "valueScript": {
+                  "code": 'Latn',
+                  "source": {
+                    "code": 'iso15924'
+                  }
+                }
+              },
+              "type": 'transliteration',
+              "standard": {
+                "value": 'ALA-LC Romanization Tables'
+              },
+              "value": 'Rea Metaru Shigen Saisei Gijutsu Kenkyūkai'
+            }
+          ],
+          type: 'organization'
+        }
+      ],
+      role: [
+        {
+          "value": 'creator',
+          "code": 'cre',
+          "uri": 'http://id.loc.gov/vocabulary/relators/cre',
+          "source": {
+            "code": 'marcrelator',
+            "uri": 'http://id.loc.gov/vocabulary/relators/'
+          }
+        }
+      ]
+    }
+  ]
+}
+
 14. Name with et al.
 <name type="personal">
   <namePart>Frydman, Judith</namePart>


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #310 