### PR TITLE
Add example 9b for multiple names with no roles to MODS name mappings

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_name.txt
+++ b/mods_cocina_mappings/mods_to_cocina_name.txt
@@ -569,6 +569,49 @@ Use "term of address" for "ordinal" if type of term cannot be determined from so
   ]
 }
 
+9b. Multiple names, no roles
+<name type="personal" usage="primary">
+  <namePart>Sarmiento, Domingo Faustino</namePart>
+  <namePart type="date">1811-1888</namePart>
+</name>
+<name type="personal">
+  <namePart>Rojas, Ricardo</namePart>
+  <namePart type="date">1882-1957</namePart>
+</name>
+{
+  "contributor": [
+    {
+      "name": [
+        "structuredValue": [
+          {
+            "value": 'Sarmiento, Domingo Faustino'
+          },
+          {
+            "type": 'life dates',
+            "value": '1811-1888'
+          }
+        ]
+      ],
+      "type": 'person',
+      "status": 'primary'
+    },
+    {
+      "name": [
+        "structuredValue": [
+          {
+            "value": 'Rojas, Ricardo'
+          },
+          {
+            "type": 'life dates',
+            "value": '1882-1957'
+          }
+        ]
+      ],
+      "type": 'person'
+    }
+  ]
+}
+
 10. Multiple names, no primary
 <name type="personal">
   <namePart>Gaiman, Neil</namePart>


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?
Closes #314 