### PR TITLE
classification mappings: make JSON parseable

### DIFF
--- a/mods_cocina_mappings/mods_to_cocina_classification.txt
+++ b/mods_cocina_mappings/mods_to_cocina_classification.txt
@@ -22,8 +22,6 @@
       "source": {
         "code": "ddc",
         "version": "11th edition"
-          }
-        ]
       }
     }
   ]


### PR DESCRIPTION
**NOTE:  Person merging should ensure that any mapping changes are ticketed as a cocina mapping in dor-services-app, e.g. dor-services-app/issues/1251**

## Why was this change made?

because when machine parsing JSON, it has to parse!